### PR TITLE
Guard against empty pip install

### DIFF
--- a/performance/venv.py
+++ b/performance/venv.py
@@ -495,14 +495,16 @@ class VirtualEnvironment(object):
         self.run_cmd(cmd)
 
         # install indirect requirements
-        cmd = pip_program + ['install']
-        cmd.extend(requirements.indirect_req)
-        self.run_cmd(cmd)
+        if requirements.indirect_req:
+            cmd = pip_program + ['install']
+            cmd.extend(requirements.indirect_req)
+            self.run_cmd(cmd)
 
         # install requirements
-        cmd = pip_program + ['install']
-        cmd.extend(requirements.req)
-        self.run_cmd(cmd)
+        if requirements.req:
+            cmd = pip_program + ['install']
+            cmd.extend(requirements.req)
+            self.run_cmd(cmd)
 
         # install optional requirements
         for req in requirements.optional:


### PR DESCRIPTION
This fixes performance to work with pip 10 by avoiding issuing an empty `pip install`.